### PR TITLE
Fix IC-3 validation query.

### DIFF
--- a/src/03_SELECT_DSD_Has_At_Least_1_Measure.sparql
+++ b/src/03_SELECT_DSD_Has_At_Least_1_Measure.sparql
@@ -5,24 +5,20 @@ PREFIX qb:      <http://purl.org/linked-data/cube#>
 PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
 PREFIX owl:     <http://www.w3.org/2002/07/owl#>
 
-SELECT (?dsd AS ?dsdWithoutDeclaredMeasure) 
-WHERE {
-
-  {
-  	SELECT ?cp {
-  	{
-  		BIND(qb:componentProperty as ?cp)
-  	}
-  	UNION
-  	{ 	SELECT ?cp 
-  		WHERE { 
-  			?cp rdfs:subPropertyOf+ qb:componentProperty . }  
-		}
-  	}
-  }
-
+SELECT ?dsd WHERE {
   ?dsd a qb:DataStructureDefinition .
-  FILTER NOT EXISTS { ?dsd qb:component [?cp [a qb:MeasureProperty]] }
+  FILTER NOT EXISTS {
+    # ok if dsd has component with qb:measure
+    ?dsd qb:component [qb:measure ?m] .
+  }
+  FILTER NOT EXISTS {
+    # ok if component has qb:componentProperty (or a subProperty)
+    # of MeasureType
+    ?dsd qb:component ?comp .
+    ?comp ?cp ?p .
+    ?cp rdfs:subPropertyOf* qb:componentProperty .
+    ?p a qb:MeasureType .
+  }
 }
 
 #! IC-3. DSD includes measure - Every qb:DataStructureDefinition must include at least one declared measure. 

--- a/src/rdf-validator-suite.edn
+++ b/src/rdf-validator-suite.edn
@@ -2,7 +2,7 @@
              "01_SELECT_Observation_Has_At_Most_1_Dataset.sparql"
              "02_SELECT_Dataset_Has_At_Least_1_DSD.sparql"
              "02_SELECT_Dataset_Has_At_Most_1_DSD.sparql"
-             ;"03_SELECT_DSD_Has_At_Least_1_Measure.sparql"
+             "03_SELECT_DSD_Has_At_Least_1_Measure.sparql"
              "04_SELECT_Dimension_Has_At_Least_1_Range.sparql"
              "05_SELECT_Concept_Dimension_Has_At_Least_1_CodeList.sparql"
              "06_SELECT_Invalid_DSD_Component_Marked_As_Optional.sparql"


### PR DESCRIPTION
Issue #1 - Update the IC-3 validation query to handle components which
directly declare a qb:measure property. The IC-* validation queries
in the specification are defined against a 'normalised' cube (see
section 10.1 of the data cube specification). The normalisation
process inserts an extra qb:componentProperty statement for components
which directly declare a qb:meaasure property. The existing validation
query assumes this statement exists when it may not.

The updated query searches for DSD components of two types:
1. Those that declare a qb:measure directly.
2. Those that declare a qb:componentProperty (or sub-property) of type
   qb:MeasureType.

The query returns DSDs which have no components which satisfy either
of the two cases.