### PR TITLE
Manually expand search for qb:dimension and qb:measure components.

### DIFF
--- a/src/17_SELECT_All_Measures_Present_In_Measures_Dimension_Cube.sparql
+++ b/src/17_SELECT_All_Measures_Present_In_Measures_Dimension_Cube.sparql
@@ -1,45 +1,52 @@
-PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
 PREFIX qb:      <http://purl.org/linked-data/cube#>
-PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?obs1 ?numMeasures
-WHERE {
+SELECT ?dsd WHERE {
   {
-      # Count number of other measures found at each point 
-      SELECT ?numMeasures (COUNT(?obs2) AS ?count) WHERE {
+    # Count number of other measures found at each point 
+    SELECT ?dsd ?numMeasures (COUNT(?obs2) AS ?count) WHERE {      
+      {
+        # Find the DSDs and check how many measures they have
+        SELECT ?dsd (COUNT(?m) AS ?numMeasures) WHERE {
           {
-              # Find the DSDs and check how many measures they have
-              SELECT ?dsd (COUNT(?m) AS ?numMeasures) WHERE {
-                  ?dsd qb:component/qb:componentProperty ?m.
-                  ?m a qb:MeasureProperty .
-              } GROUP BY ?dsd
-          }
+            ?dsd qb:component ?comp .
+            ?comp ?cp ?m .
+            ?m a qb:MeasureProperty .
+            ?cp rdfs:subPropertyOf* qb:componentProperty .
+          } UNION {
+            ?dsd qb:component/qb:measure ?m .
+          }                  
+        } GROUP BY ?dsd
+      }
         
-          # Observation in measureType cube
-          ?obs1 qb:dataSet/qb:structure ?dsd;
-                qb:dataSet ?dataset ;
-                qb:measureType ?m1 .
+      # Observation in measureType cube
+      ?obs1 qb:dataSet/qb:structure ?dsd;
+            qb:dataSet ?dataset ;
+            qb:measureType ?m1 .
     
-          # Other observation at same dimension value
-          ?obs2 qb:dataSet ?dataset ;
-                qb:measureType ?m2 .
-          FILTER NOT EXISTS { 
-              ?dsd qb:component/qb:componentProperty ?dim .
-              FILTER (?dim != qb:measureType)
-              ?dim a qb:DimensionProperty .
-              ?obs1 ?dim ?v1 . 
-              ?obs2 ?dim ?v2. 
-              FILTER (?v1 != ?v2)
-          }
+      # Other observation at same dimension value
+      ?obs2 qb:dataSet ?dataset ;
+            qb:measureType ?m2 .
+      FILTER NOT EXISTS { 
+        {
+          ?dsd qb:component ?comp .
+          ?comp ?cp ?dim .
+          ?cp rdfs:subPropertyOf* qb:componentProperty .
+          ?dim a qb:DimensionProperty .
+        } UNION {
+          ?dsd qb:component/qb:dimension ?dim .
+        }
+              
+        FILTER (?dim != qb:measureType)              
+        ?obs1 ?dim ?v1 . 
+        ?obs2 ?dim ?v2. 
+        FILTER (?v1 != ?v2)
+      }
           
-      } GROUP BY ?obs1 ?numMeasures
-        HAVING (?count != ?numMeasures)
+    } GROUP BY ?dsd ?obs1 ?numMeasures
+      HAVING (?count != ?numMeasures)
   }
-}
-    
+}    
 
 #! IC-17. All measures present in measures dimension cube -  In a qb:DataSet which uses a Measure dimension then if there is a Observation for some combination of non-measure dimensions then there must be other Observations with the same non-measure dimension values for each of the declared measures. 
 

--- a/src/rdf-validator-suite.edn
+++ b/src/rdf-validator-suite.edn
@@ -17,7 +17,7 @@
              "14_SELECT_Dataset_Without_MeasureDimension_Obs_Has_Value.sparql"
              "15_SELECT_Dataset_With_MeasureDimension_Obs_Has_Value_For_Measure.sparql"
              "16_SELECT_Dataset_With_MeasureDimension_Obs_Has_Exactly_1_Value.sparql"
-             ;"17_SELECT_All_Measures_Present_In_Measures_Dimension_Cube.sparql"
+             "17_SELECT_All_Measures_Present_In_Measures_Dimension_Cube.sparql"
              "18_SELECT_Observations_In_Slices_Must_Be_In_Slices_Dataset.sparql"
              "19_SELECT_Collection_Values_Must_Be_From_CodeList.sparql"
              "19_SELECT_ConceptScheme_Values_Must_Be_From_CodeList.sparql"]}


### PR DESCRIPTION
Issue #2 - Update IC-17 validation to manually search for DSD
components which declare either a qb:measure (or qb:dimension) or
which specify a qb:componentProperty (or sub-property) of a
qb:MeasureType (or qb:DimensionType).

Project the invalid DSD URIs from the outer SELECT query.